### PR TITLE
help flag & subcommand refactor

### DIFF
--- a/src/parse_args_test.go
+++ b/src/parse_args_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"flag"
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -86,22 +85,6 @@ func TestParseArgs(t *testing.T) {
 			expectedFlags:    nil,
 			expectedNonFlags: nil,
 			expectError:      false,
-		},
-		{
-			name:                 "Unrecognized flag",
-			args:                 []string{"--unknown-flag", "value"},
-			expectedFlags:        nil,
-			expectedNonFlags:     nil,
-			expectError:          true,
-			expectedErrorMessage: fmt.Errorf("unrecognized flag: unknown-flag"),
-		},
-		{
-			name:                 "Too many dashes on flag",
-			args:                 []string{"---flag1", "value"},
-			expectedFlags:        nil,
-			expectedNonFlags:     nil,
-			expectError:          true,
-			expectedErrorMessage: fmt.Errorf("unrecognized flag: -flag1"),
 		},
 	}
 

--- a/src/subcommand.go
+++ b/src/subcommand.go
@@ -14,6 +14,19 @@ func printCmdErr(e string) {
 	fmt.Printf("%s\n Try --help to list subcommands and options.\n", e)
 }
 
+func baseHelp() {
+	fmt.Printf("semantifly currently has the following subcommands: add, delete, update, search.\nUse --help on these subcommands for more information.\n")
+}
+
+func containsHelpFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--help" || arg == "-h" {
+			return true
+		}
+	}
+	return false
+}
+
 func isFlag(fs *flag.FlagSet, name string) bool {
 	f := fs.Lookup(name)
 	return f != nil
@@ -130,6 +143,11 @@ func CommandReadRun() {
 		makeLocalCopy := cmd.Bool("copy", false, "Whether to copy and use the file as it is now, or dynamically access it")
 		indexPath := cmd.String("index-path", "", "Path to the index file")
 
+		if containsHelpFlag(args) {
+			cmd.Usage()
+			return
+		}
+
 		flags, nonFlags, err := parseArgs(args, cmd)
 		if err != nil {
 			printCmdErr(fmt.Sprintf("Error: %v", err))
@@ -160,6 +178,11 @@ func CommandReadRun() {
 		deleteLocalCopy := cmd.Bool("copy", false, "Whether to delete the copy made")
 		indexPath := cmd.String("index-path", "", "Path to the index file")
 
+		if containsHelpFlag(args) {
+			cmd.Usage()
+			return
+		}
+
 		flags, nonFlags, err := parseArgs(args, cmd)
 		if err != nil {
 			printCmdErr(fmt.Sprintf("Error: %v", err))
@@ -186,6 +209,11 @@ func CommandReadRun() {
 	case "get":
 		cmd := flag.NewFlagSet("get", flag.ExitOnError)
 		indexPath := cmd.String("index-path", "", "Path to the index file")
+
+		if containsHelpFlag(args) {
+			cmd.Usage()
+			return
+		}
 
 		flags, nonFlags, err := parseArgs(args, cmd)
 		if err != nil {
@@ -216,6 +244,11 @@ func CommandReadRun() {
 		sourceType := cmd.String("source-type", "", "How to access the content")
 		makeLocalCopy := cmd.String("copy", "false", "Whether to copy and use the file as it is now, or dynamically access it")
 		indexPath := cmd.String("index-path", "", "Path to the index file")
+
+		if containsHelpFlag(args) {
+			cmd.Usage()
+			return
+		}
 
 		flags, nonFlags, err := parseArgs(args, cmd)
 		if err != nil {
@@ -248,6 +281,11 @@ func CommandReadRun() {
 		indexPath := cmd.String("index-path", "", "Path to the index file")
 		topN := cmd.Int("n", 1, "Top n search results")
 
+		if containsHelpFlag(args) {
+			cmd.Usage()
+			return
+		}
+
 		flags, nonFlags, err := parseArgs(args, cmd)
 
 		if err != nil {
@@ -279,6 +317,12 @@ func CommandReadRun() {
 		}
 
 		subcommands.PrintSearchResults(searchResults)
+
+	case "--help":
+		baseHelp()
+
+	case "-h":
+		baseHelp()
 
 	default:
 		printCmdErr("No valid subcommand provided.")

--- a/src/subcommand.go
+++ b/src/subcommand.go
@@ -18,20 +18,6 @@ func baseHelp() {
 	fmt.Printf("semantifly currently has the following subcommands: add, delete, update, search.\nUse --help on these subcommands for more information.\n")
 }
 
-func containsHelpFlag(args []string) bool {
-	for _, arg := range args {
-		if arg == "--help" || arg == "-h" {
-			return true
-		}
-	}
-	return false
-}
-
-func isFlag(fs *flag.FlagSet, name string) bool {
-	f := fs.Lookup(name)
-	return f != nil
-}
-
 func isBoolFlag(fs *flag.FlagSet, name string) bool {
 	f := fs.Lookup(name)
 	if f == nil {
@@ -55,27 +41,12 @@ func parseArgs(args []string, cmd *flag.FlagSet) ([]string, []string, error) {
 		arg := args[i]
 		if strings.HasPrefix(arg, "-") {
 			if strings.Contains(arg, "=") {
-				parts := strings.SplitN(arg, "=", 2)
-				if strings.HasPrefix(parts[0], "--") {
-					flagName = parts[0][2:]
-				} else {
-					flagName = parts[0][1:]
-				}
-
-				if !isFlag(cmd, flagName) {
-					return nil, nil, fmt.Errorf("unrecognized flag: %s", flagName)
-				}
-
 				flags = append(flags, arg)
 			} else {
 				if strings.HasPrefix(arg, "--") {
 					flagName = arg[2:]
 				} else {
 					flagName = arg[1:]
-				}
-
-				if !isFlag(cmd, flagName) {
-					return nil, nil, fmt.Errorf("unrecognized flag: %s", flagName)
 				}
 
 				flags = append(flags, arg)
@@ -143,11 +114,6 @@ func CommandReadRun() {
 		makeLocalCopy := cmd.Bool("copy", false, "Whether to copy and use the file as it is now, or dynamically access it")
 		indexPath := cmd.String("index-path", "", "Path to the index file")
 
-		if containsHelpFlag(args) {
-			cmd.Usage()
-			return
-		}
-
 		flags, nonFlags, err := parseArgs(args, cmd)
 		if err != nil {
 			printCmdErr(fmt.Sprintf("Error: %v", err))
@@ -156,12 +122,13 @@ func CommandReadRun() {
 
 		reorderedArgs := append(flags, nonFlags...)
 
+		// Parse has to come before to ensure --help flag is seen
+		cmd.Parse(reorderedArgs)
+
 		if len(nonFlags) < 1 {
 			printCmdErr("Add subcommand requires at least one input arg append to index log")
 			return
 		}
-
-		cmd.Parse(reorderedArgs)
 
 		args := subcommands.AddArgs{
 			IndexPath:  *indexPath,
@@ -178,11 +145,6 @@ func CommandReadRun() {
 		deleteLocalCopy := cmd.Bool("copy", false, "Whether to delete the copy made")
 		indexPath := cmd.String("index-path", "", "Path to the index file")
 
-		if containsHelpFlag(args) {
-			cmd.Usage()
-			return
-		}
-
 		flags, nonFlags, err := parseArgs(args, cmd)
 		if err != nil {
 			printCmdErr(fmt.Sprintf("Error: %v", err))
@@ -191,12 +153,12 @@ func CommandReadRun() {
 
 		reorderedArgs := append(flags, nonFlags...)
 
+		cmd.Parse(reorderedArgs)
+
 		if len(nonFlags) < 1 {
 			printCmdErr("Delete subcommand requires at least one input arg.")
 			return
 		}
-
-		cmd.Parse(reorderedArgs)
 
 		args := subcommands.DeleteArgs{
 			IndexPath:  *indexPath,
@@ -210,11 +172,6 @@ func CommandReadRun() {
 		cmd := flag.NewFlagSet("get", flag.ExitOnError)
 		indexPath := cmd.String("index-path", "", "Path to the index file")
 
-		if containsHelpFlag(args) {
-			cmd.Usage()
-			return
-		}
-
 		flags, nonFlags, err := parseArgs(args, cmd)
 		if err != nil {
 			printCmdErr(fmt.Sprintf("Error: %v", err))
@@ -223,12 +180,12 @@ func CommandReadRun() {
 
 		reorderedArgs := append(flags, nonFlags...)
 
+		cmd.Parse(reorderedArgs)
+
 		if len(nonFlags) != 1 {
 			printCmdErr("Get subcommand requires exactly one arg.")
 			return
 		}
-
-		cmd.Parse(reorderedArgs)
 
 		name := cmd.Args()[0]
 		args := subcommands.GetArgs{
@@ -245,11 +202,6 @@ func CommandReadRun() {
 		makeLocalCopy := cmd.String("copy", "false", "Whether to copy and use the file as it is now, or dynamically access it")
 		indexPath := cmd.String("index-path", "", "Path to the index file")
 
-		if containsHelpFlag(args) {
-			cmd.Usage()
-			return
-		}
-
 		flags, nonFlags, err := parseArgs(args, cmd)
 		if err != nil {
 			printCmdErr(fmt.Sprintf("Error: %v", err))
@@ -258,12 +210,12 @@ func CommandReadRun() {
 
 		reorderedArgs := append(flags, nonFlags...)
 
+		cmd.Parse(reorderedArgs)
+
 		if len(nonFlags) != 2 {
 			printCmdErr("Update subcommand requires two input args - index name and updated URI")
 			return
 		}
-
-		cmd.Parse(reorderedArgs)
 
 		args := subcommands.UpdateArgs{
 			IndexPath:  *indexPath,
@@ -281,11 +233,6 @@ func CommandReadRun() {
 		indexPath := cmd.String("index-path", "", "Path to the index file")
 		topN := cmd.Int("n", 1, "Top n search results")
 
-		if containsHelpFlag(args) {
-			cmd.Usage()
-			return
-		}
-
 		flags, nonFlags, err := parseArgs(args, cmd)
 
 		if err != nil {
@@ -295,12 +242,12 @@ func CommandReadRun() {
 
 		reorderedArgs := append(flags, nonFlags...)
 
+		cmd.Parse(reorderedArgs)
+
 		if len(nonFlags) != 1 {
 			printCmdErr("Search subcommand requires exactly one arg.")
 			return
 		}
-
-		cmd.Parse(reorderedArgs)
 
 		searchTerm := cmd.Args()[0]
 		args := subcommands.LexicalSearchArgs{

--- a/src/subcommand.go
+++ b/src/subcommand.go
@@ -14,8 +14,43 @@ func printCmdErr(e string) {
 	fmt.Printf("%s\n Try --help to list subcommands and options.\n", e)
 }
 
+type SubcommandInfo struct {
+	Command     string
+	Description string
+}
+
+var commandHelpInfo = []SubcommandInfo{
+	{
+		Command:     "add",
+		Description: "Add new data to the index",
+	},
+	{
+		Command:     "delete",
+		Description: "Delete data from the index",
+	},
+	{
+		Command:     "get",
+		Description: "Retrieve data from the index",
+	},
+	{
+		Command:     "update",
+		Description: "Update existing data in the index",
+	},
+	{
+		Command:     "search",
+		Description: "Search (lexically) for a term in the index",
+	},
+}
+
 func baseHelp() {
-	fmt.Printf("semantifly currently has the following subcommands: add, delete, update, search.\nUse --help on these subcommands for more information.\n")
+	fmt.Println("Semantifly Help")
+	fmt.Println("Available subcommands:")
+
+	for _, subcommand := range commandHelpInfo {
+		fmt.Printf("  %-10s %s\n", subcommand.Command, subcommand.Description)
+	}
+
+	fmt.Println("\nUse 'semantifly <subcommand> --help' for more information about a specific subcommand.")
 }
 
 func isBoolFlag(fs *flag.FlagSet, name string) bool {

--- a/src/subcommand_test.go
+++ b/src/subcommand_test.go
@@ -85,6 +85,16 @@ func TestCommandRun(t *testing.T) {
 	}
 	tempFile.Close()
 
+	// Testing Help Flag subcommand
+	expectedHelpString := "semantifly currently has the following subcommands: add, delete, update, search.\nUse --help on these subcommands for more information.\n"
+	if err := runAndCheckStdoutContains("--help", expectedHelpString, nil); err != nil {
+		t.Errorf("Failed to execute --help flag subcommand: %v", err)
+	}
+
+	if err := runAndCheckStdoutContains("-h", expectedHelpString, nil); err != nil {
+		t.Errorf("Failed to execute --help flag subcommand: %v", err)
+	}
+
 	// Testing Add subcommand for a non-existing file
 	args := []string{"nofile"}
 	if err := runAndCheckStdoutContains("add", "file does not exist", args); err != nil {
@@ -132,7 +142,6 @@ func TestCommandRun(t *testing.T) {
 	//Testing the commands for webpage sourcetype
 	testWebpageURI := "http://echo.jsontest.com/title/lorem/content/ipsum"
 
-	
 	// Testing Add subcommand for webpage
 	webpageAddArgs := []string{testWebpageURI, "--source-type", "webpage"}
 	if err := runAndCheckStdoutContains("add", "added successfully", webpageAddArgs); err != nil {

--- a/src/subcommand_test.go
+++ b/src/subcommand_test.go
@@ -108,7 +108,7 @@ func TestCommandRun(t *testing.T) {
 	tempFile.Close()
 
 	// Testing Help Flag
-	expectedHelpString := "semantifly currently has the following subcommands: add, delete, update, search.\nUse --help on these subcommands for more information.\n"
+	expectedHelpString := "Use 'semantifly <subcommand> --help' for more information about a specific subcommand."
 	if err := runAndCheckStdoutContains("--help", expectedHelpString, nil); err != nil {
 		t.Errorf("Failed to execute --help flag subcommand: %v", err)
 	}

--- a/src/subcommand_test.go
+++ b/src/subcommand_test.go
@@ -11,6 +11,206 @@ import (
 	"testing"
 )
 
+// Main is run before every test to set up the testing folder & semantifly
+func TestMain(m *testing.M) {
+	// Setup
+	err := os.Chdir("..")
+	if err != nil {
+		fmt.Printf("Failed to change directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	semantifly_dir := os.Getenv("HOME") + "/opt/semantifly"
+	cmd := exec.Command("bash", "setup.sh")
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	if err != nil {
+		fmt.Printf("Setup for semantifly failed: %v\nStderr: %s\n", err, stderr.String())
+		os.Exit(1)
+	}
+
+	// Adding semantifly to PATH
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", oldPath+":"+semantifly_dir)
+
+	// Run tests
+	code := m.Run()
+
+	// Cleanup
+	os.Setenv("PATH", oldPath)
+	os.Remove("index.list")
+
+	os.Exit(code)
+}
+
+func TestHelpFlag(t *testing.T) {
+	expectedHelpString := "Use 'semantifly <subcommand> --help' for more information about a specific subcommand."
+
+	t.Run("--help", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("--help", expectedHelpString, nil); err != nil {
+			t.Errorf("Failed to execute --help flag: %v", err)
+		}
+	})
+
+	t.Run("-h", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("-h", expectedHelpString, nil); err != nil {
+			t.Errorf("Failed to execute -h flag: %v", err)
+		}
+	})
+}
+
+func TestAddSubcommand(t *testing.T) {
+	tempFile, err := createTempFile("This is a test file for semantifly subcommands.")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	defer os.Remove(tempFile)
+
+	t.Run("Help", func(t *testing.T) {
+		if err := runAndCheckStderrContains("add", "Usage of add:", []string{"--help"}); err != nil {
+			t.Errorf("Failed to execute 'add --help': %v", err)
+		}
+	})
+
+	t.Run("Non-existing file", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("add", "file does not exist", []string{"nofile"}); err != nil {
+			t.Errorf("Failed to execute 'add' with non-existing file: %v", err)
+		}
+	})
+
+	t.Run("Bad flag", func(t *testing.T) {
+		if err := runAndCheckStderrContains("add", "flag provided but not defined: -badflag", []string{"--badflag"}); err != nil {
+			t.Errorf("Failed to execute 'add' with bad flag: %v", err)
+		}
+	})
+
+	t.Run("Existing file", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("add", "added successfully", []string{tempFile}); err != nil {
+			t.Errorf("Failed to execute 'add' with existing file: %v", err)
+		}
+	})
+}
+
+func TestGetSubcommand(t *testing.T) {
+	tempFile, err := createTempFile("This is a test file for semantifly subcommands.")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	defer os.Remove(tempFile)
+
+	// add file
+	if err := runAndCheckStdoutContains("add", "added successfully", []string{tempFile}); err != nil {
+		t.Fatalf("Failed to add file to index: %v", err)
+	}
+
+	t.Run("Get existing file", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("get", "This is a test file", []string{tempFile}); err != nil {
+			t.Errorf("Failed to execute 'get' for existing file: %v", err)
+		}
+	})
+
+	t.Run("Get after delete", func(t *testing.T) {
+		runAndCheckStdoutContains("delete", "deleted successfully", []string{tempFile})
+		if err := runAndCheckStdoutContains("get", "empty index file", []string{tempFile}); err != nil {
+			t.Errorf("Failed to execute 'get' after delete: %v", err)
+		}
+	})
+}
+
+func TestUpdateSubcommand(t *testing.T) {
+	tempFile, err := createTempFile("This is a test file for semantifly subcommands.")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	defer os.Remove(tempFile)
+
+	updatedTempFile, err := createTempFile("This is an updated test file for semantifly subcommands.")
+	if err != nil {
+		t.Fatalf("Failed to create updated temporary file: %v", err)
+	}
+	defer os.Remove(updatedTempFile)
+
+	// add file
+	runAndCheckStdoutContains("add", "added successfully", []string{tempFile})
+
+	t.Run("Update without URI", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("update", "Update subcommand requires two input args", []string{tempFile}); err != nil {
+			t.Errorf("Failed to execute 'update' without URI: %v", err)
+		}
+	})
+
+	t.Run("Update with new file", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("update", "updated successfully", []string{tempFile, updatedTempFile}); err != nil {
+			t.Errorf("Failed to execute 'update' with new file: %v", err)
+		}
+	})
+}
+
+func TestDeleteSubcommand(t *testing.T) {
+	tempFile, err := createTempFile("This is a test file for semantifly subcommands.")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	defer os.Remove(tempFile)
+
+	// add file
+	runAndCheckStdoutContains("add", "added successfully", []string{tempFile})
+
+	t.Run("Delete existing file", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("delete", "deleted successfully", []string{tempFile}); err != nil {
+			t.Errorf("Failed to execute 'delete' for existing file: %v", err)
+		}
+	})
+
+	t.Run("Delete from empty index", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("delete", "empty index file", []string{tempFile}); err != nil {
+			t.Errorf("Failed to execute 'delete' on empty index: %v", err)
+		}
+	})
+}
+
+func TestWebpageOperations(t *testing.T) {
+	testWebpageURI := "http://echo.jsontest.com/title/lorem/content/ipsum"
+	updatedWebpageURI := "http://echo.jsontest.com/title/foo/content/bar"
+
+	t.Run("Add webpage", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("add", "added successfully", []string{testWebpageURI}); err != nil {
+			t.Errorf("Failed to execute 'add' for webpage: %v", err)
+		}
+	})
+
+	t.Run("Get webpage", func(t *testing.T) {
+		webpageContent := getWebpageContent(t, testWebpageURI)
+		if err := runAndCheckStdoutContains("get", string(webpageContent), []string{testWebpageURI}); err != nil {
+			t.Errorf("Failed to execute 'get' for webpage: %v", err)
+		}
+	})
+
+	// to do: after we refactor name & uri to be different, need to change the tests after update to get / delete new name, not old name
+	t.Run("Update webpage", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("update", "updated successfully", []string{testWebpageURI, updatedWebpageURI}); err != nil {
+			t.Errorf("Failed to execute 'update' for webpage: %v", err)
+		}
+	})
+
+	t.Run("Get webpage", func(t *testing.T) {
+		webpageContent := getWebpageContent(t, updatedWebpageURI)
+		if err := runAndCheckStdoutContains("get", string(webpageContent), []string{testWebpageURI}); err != nil {
+			t.Errorf("Failed to execute 'get' for webpage: %v", err)
+		}
+	})
+
+	t.Run("Delete webpage", func(t *testing.T) {
+		if err := runAndCheckStdoutContains("delete", "deleted successfully", []string{testWebpageURI}); err != nil {
+			t.Errorf("Failed to execute 'delete' for webpage: %v", err)
+		}
+	})
+}
+
 func runAndCheckStdoutContains(subcommand string, wantedStdoutSubstr string, args []string) error {
 	allArgs := append([]string{subcommand}, args...)
 	cmd := exec.Command("semantifly", allArgs...)
@@ -56,187 +256,36 @@ func runAndCheckStderrContains(subcommand string, wantedStderrSubstr string, arg
 	return nil
 }
 
-func TestCommandRun(t *testing.T) {
-	// Setup
-	err := os.Chdir("..")
-	if err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-
-	semantifly_dir := os.Getenv("HOME") + "/opt/semantifly"
-	cmd := exec.Command("bash", "setup.sh")
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err = cmd.Run()
-	if err != nil {
-		t.Fatalf("Setup for semantifly failed: %v\nStderr: %s", err, stderr.String())
-	}
-
-	// Adding semantifly to PATH
-	oldPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", oldPath)
-
-	os.Setenv("PATH", oldPath+":"+semantifly_dir)
-
-	// Making a temp file for testing
+func createTempFile(content string) (string, error) {
 	tempFile, err := os.CreateTemp("", "semantifly_test_*.txt")
 	if err != nil {
-		t.Fatalf("Failed to create temporary file: %v", err)
+		return "", fmt.Errorf("Failed to create temporary file: %v", err)
 	}
-	defer os.Remove(tempFile.Name())
 
-	testContent := "This is a test file for semantifly subcommands."
-	if _, err := tempFile.WriteString(testContent); err != nil {
-		t.Fatalf("Failed to write to temporary file: %v", err)
-	}
-	tempFile.Close()
-
-	// Making a second file to test the update command
-	updatedTempFile, err := os.CreateTemp("", "semantifly_test_updated_*.txt")
-	if err != nil {
-		t.Fatalf("Failed to create temporary file: %v", err)
-	}
-	defer os.Remove(updatedTempFile.Name())
-
-	updatedContent := "This is an updated test file for semantifly subcommands."
-	if _, err := updatedTempFile.WriteString(updatedContent); err != nil {
-		t.Fatalf("Failed to write to temporary file: %v", err)
+	if _, err := tempFile.WriteString(content); err != nil {
+		os.Remove(tempFile.Name())
+		return "", fmt.Errorf("Failed to write to temporary file: %v", err)
 	}
 	tempFile.Close()
 
-	// Testing Help Flag
-	expectedHelpString := "Use 'semantifly <subcommand> --help' for more information about a specific subcommand."
-	if err := runAndCheckStdoutContains("--help", expectedHelpString, nil); err != nil {
-		t.Errorf("Failed to execute --help flag subcommand: %v", err)
-	}
+	return tempFile.Name(), nil
+}
 
-	if err := runAndCheckStdoutContains("-h", expectedHelpString, nil); err != nil {
-		t.Errorf("Failed to execute --help flag subcommand: %v", err)
-	}
-
-	// Testing Help Flag on subcommand add
-	// Have to use stderr function since --help prints to stderr
-	args := []string{"--help"}
-	if err := runAndCheckStderrContains("add", "Usage of add:", args); err != nil {
-		t.Errorf("Failed to execute 'add --help' subcommand: %v", err)
-	}
-
-	// Testing Help Flag on subcommand delete
-	args = []string{"--help"}
-	if err := runAndCheckStderrContains("delete", "Usage of delete:", args); err != nil {
-		t.Errorf("Failed to execute 'delete --help' subcommand: %v", err)
-	}
-
-	// Testing Add subcommand for a non-existing file
-	args = []string{"nofile"}
-	if err := runAndCheckStdoutContains("add", "file does not exist", args); err != nil {
-		t.Errorf("Failed to execute 'add' subcommand: %v", err)
-	}
-
-	// Testing nonexistent flag on Add
-	args = []string{"--badflag"}
-	if err := runAndCheckStderrContains("add", "flag provided but not defined: -badflag", args); err != nil {
-		t.Errorf("Failed to execute 'add --help' subcommand: %v", err)
-	}
-
-	// Testing Add subcommand for an existing file
-	args = []string{tempFile.Name()}
-	if err := runAndCheckStdoutContains("add", "added successfully", args); err != nil {
-		t.Errorf("Failed to execute 'add' subcommand: %v", err)
-	}
-
-	defer os.Remove("index.list")
-
-	// Testing Get subcommand
-	if err := runAndCheckStdoutContains("get", testContent, args); err != nil {
-		t.Errorf("Failed to execute 'get' subcommand: %v", err)
-	}
-
-	// Testing Update subcommand without passing in the updated URI
-	if err := runAndCheckStdoutContains("update", "Update subcommand requires two input args", args); err != nil {
-		t.Errorf("Failed to execute 'delete' subcommand: %v", err)
-	}
-
-	// Testing Update subcommand
-	updateArgs := []string{tempFile.Name(), updatedTempFile.Name()}
-	if err := runAndCheckStdoutContains("update", "updated successfully", updateArgs); err != nil {
-		t.Errorf("Failed to execute 'delete' subcommand: %v", err)
-	}
-
-	// Testing Delete subcommand
-	if err := runAndCheckStdoutContains("delete", "deleted successfully", args); err != nil {
-		t.Errorf("Failed to execute 'delete' subcommand: %v", err)
-	}
-
-	// Testing Get command after deleting the entry
-	if err := runAndCheckStdoutContains("get", "empty index file", args); err != nil {
-		t.Errorf("Failed to execute 'get' subcommand: %v", err)
-	}
-
-	// Testing Delete subcommand after deleting the entry
-	if err := runAndCheckStdoutContains("delete", "empty index file", args); err != nil {
-		t.Errorf("Failed to execute 'delete' subcommand: %v", err)
-	}
-
-	//Testing the commands for webpage sourcetype
-	testWebpageURI := "http://echo.jsontest.com/title/lorem/content/ipsum"
-
-	// Testing Add subcommand for webpage
-	webpageAddArgs := []string{testWebpageURI}
-	if err := runAndCheckStdoutContains("add", "added successfully", webpageAddArgs); err != nil {
-		t.Errorf("Failed to execute 'add' subcommand: %v", err)
-	}
-	defer os.Remove("index.list")
-
-	// Fetching content from webpage URI
-	resp, err := http.Get(testWebpageURI)
+func getWebpageContent(t *testing.T, url string) []byte {
+	resp, err := http.Get(url)
 	if err != nil {
-		t.Errorf("failed to fetch web page: %v", err)
+		t.Fatalf("failed to fetch web page: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("web page returned non-OK status: %s", resp.Status)
+		t.Fatalf("web page returned non-OK status: %s", resp.Status)
 	}
 
-	webpageContent, err := io.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("failed to read web page content: %v", err)
+		t.Fatalf("failed to read web page content: %v", err)
 	}
 
-	// Testing Get subcommand for webpage
-	webpageArgs := []string{testWebpageURI}
-	if err := runAndCheckStdoutContains("get", string(webpageContent), webpageArgs); err != nil {
-		t.Errorf("Failed to execute 'get' subcommand: %v", err)
-	}
-
-	// Testing Update subcommand without passing in the updated web URI
-	if err := runAndCheckStdoutContains("update", "Update subcommand requires two input args", webpageArgs); err != nil {
-		t.Errorf("Failed to execute 'delete' subcommand: %v", err)
-	}
-
-	// Testing Update subcommand for webpage URI
-	updatedWebpageURI := "http://echo.jsontest.com/title/foo/content/bar"
-	webpageUpdateArgs := []string{testWebpageURI, updatedWebpageURI}
-	if err := runAndCheckStdoutContains("update", "updated successfully", webpageUpdateArgs); err != nil {
-		t.Errorf("Failed to execute 'delete' subcommand: %v", err)
-	}
-
-	// Testing Delete subcommand
-	if err := runAndCheckStdoutContains("delete", "deleted successfully", webpageArgs); err != nil {
-		t.Errorf("Failed to execute 'delete' subcommand: %v", err)
-	}
-
-	// Testing Get command after deleting the entry
-	if err := runAndCheckStdoutContains("get", "empty index file", webpageArgs); err != nil {
-		t.Errorf("Failed to execute 'get' subcommand: %v", err)
-	}
-
-	// Testing Delete subcommand after deleting the entry
-	if err := runAndCheckStdoutContains("delete", "empty index file", webpageArgs); err != nil {
-		t.Errorf("Failed to execute 'delete' subcommand: %v", err)
-	}
+	return content
 }

--- a/src/subcommand_test.go
+++ b/src/subcommand_test.go
@@ -136,11 +136,18 @@ func TestCommandRun(t *testing.T) {
 		t.Errorf("Failed to execute 'add' subcommand: %v", err)
 	}
 
+	// Testing nonexistent flag on Add
+	args = []string{"--badflag"}
+	if err := runAndCheckStderrContains("add", "flag provided but not defined: -badflag", args); err != nil {
+		t.Errorf("Failed to execute 'add --help' subcommand: %v", err)
+	}
+
 	// Testing Add subcommand for an existing file
 	args = []string{tempFile.Name()}
 	if err := runAndCheckStdoutContains("add", "added successfully", args); err != nil {
 		t.Errorf("Failed to execute 'add' subcommand: %v", err)
 	}
+
 	defer os.Remove("index.list")
 
 	// Testing Get subcommand

--- a/src/subcommand_test.go
+++ b/src/subcommand_test.go
@@ -13,7 +13,6 @@ import (
 
 // Main is run before every test to set up the testing folder & semantifly
 func TestMain(m *testing.M) {
-	// Setup
 	err := os.Chdir("..")
 	if err != nil {
 		fmt.Printf("Failed to change directory: %v\n", err)
@@ -33,14 +32,13 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	// Adding semantifly to PATH
 	oldPath := os.Getenv("PATH")
 	os.Setenv("PATH", oldPath+":"+semantifly_dir)
 
-	// Run tests
+	// run tests
 	code := m.Run()
 
-	// Cleanup
+	// clean up
 	os.Setenv("PATH", oldPath)
 	os.Remove("index.list")
 
@@ -102,7 +100,6 @@ func TestGetSubcommand(t *testing.T) {
 	}
 	defer os.Remove(tempFile)
 
-	// add file
 	if err := runAndCheckStdoutContains("add", "added successfully", []string{tempFile}); err != nil {
 		t.Fatalf("Failed to add file to index: %v", err)
 	}
@@ -134,7 +131,6 @@ func TestUpdateSubcommand(t *testing.T) {
 	}
 	defer os.Remove(updatedTempFile)
 
-	// add file
 	runAndCheckStdoutContains("add", "added successfully", []string{tempFile})
 
 	t.Run("Update without URI", func(t *testing.T) {
@@ -157,7 +153,6 @@ func TestDeleteSubcommand(t *testing.T) {
 	}
 	defer os.Remove(tempFile)
 
-	// add file
 	runAndCheckStdoutContains("add", "added successfully", []string{tempFile})
 
 	t.Run("Delete existing file", func(t *testing.T) {


### PR DESCRIPTION
added functionality for help flag
refactored subcommand.go for better readability and implementation. it now maps each subcommand to a function call and a description, to be easily used for --help and also future implementation